### PR TITLE
WEAR-13239 dependabotを入れる

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## JIRA
<!-- タイトルの先頭にも　Jira の project ID を忘れずに追加してください  -->
https://zozo.rickcloud.jp/jira/browse/WEAR-13239

## 概要
dependabotを有効化するymlを作成しました。
cf) https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically

## 変更点
新規ファイル

## キャプチャ
**画面名**
|BEFORE|AFTER|
|:------:|:------:|
|<img src="" width="250">|<img src="" width="250">|

## レビュー観点

## テストした内容
- なし
https://github.com/murs313/github-actions-test/pull/46